### PR TITLE
fix: Use recommended machine tags

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -258,7 +258,7 @@ workflows:
           name: "ui-tests-<<matrix.system-image>>"
           executor:
             name: android/android-machine
-            tag: "202102-01"
+            tag: "default"
           checkout: false
           pre-steps:
             - run:
@@ -277,10 +277,10 @@ workflows:
           filters: *filters
       - test-emulator-commands:
           system-image: "system-images;android-29;default;x86"
-          tag: "202102-01"
+          tag: "default"
           filters: *filters
       - test-start-emulator-and-run-tests:
-          tag: "202102-01"
+          tag: "default"
           filters: *filters
       - test-fastlane
       - orb-tools/pack:

--- a/src/examples/granular-commands.yml
+++ b/src/examples/granular-commands.yml
@@ -5,12 +5,12 @@ description: |
 usage:
   version: 2.1
   orbs:
-    android: circleci/android@2.0
+    android: circleci/android@2.4.0
   jobs:
     test:
       executor:
         name: android/android-machine
-        tag: "2021.10.1"
+        tag: "default"
         resource-class: large
       steps:
         - checkout

--- a/src/examples/override-machine-resource-class.yml
+++ b/src/examples/override-machine-resource-class.yml
@@ -3,11 +3,12 @@ description: |
 usage:
   version: 2.1
   orbs:
-    android: circleci/android@2.0
+    android: circleci/android@2.4.0
   workflows:
     test:
       jobs:
         - android/run-ui-tests:
             executor:
               name: android/android-machine
+              tag: "default"
               resource-class: xlarge

--- a/src/examples/run-ui-tests-job.yml
+++ b/src/examples/run-ui-tests-job.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    android: circleci/android@2.0
+    android: circleci/android@2.4.0
   workflows:
     test:
       jobs:

--- a/src/examples/start-emulator-and-run-tests.yml
+++ b/src/examples/start-emulator-and-run-tests.yml
@@ -6,11 +6,12 @@ description: |
 usage:
   version: 2.1
   orbs:
-    android: circleci/android@2.0
+    android: circleci/android@2.4.0
   jobs:
     test:
       executor:
         name: android/android-machine
+        tag: "default"
         resource-class: large
       steps:
         - checkout

--- a/src/examples/test-matrix.yml
+++ b/src/examples/test-matrix.yml
@@ -4,7 +4,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    android: circleci/android@2.0
+    android: circleci/android@2.4.0
   workflows:
     test:
       jobs:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
- Per [Android Image Deprecations and EOL for 2024](https://discuss.circleci.com/t/android-image-deprecations-and-eol-for-2024/50180) the recommended tags (for android/machine) are default and edge.  This PR addresses these.
- Orb version refs were updated to reflect the current/latest android orb version in examples.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
- Replace android/machine tags to `default`
- Update android/orb version to "2.4.0"
